### PR TITLE
bugfix(isparta-loader) change isparta to isparta-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react": "^2.3.0",
     "file-loader": "^0.8.5",
     "immutable": "^3.7.6",
-    "isparta": "^4.0.0",
+    "isparta-loader": "^2.0.0",
     "jasmine": "~2.3.2",
     "jasmine-core": "~2.3.4",
     "karma": "~0.13.9",


### PR DESCRIPTION
Isparta doesn't provide a `fn` as callback for webpack, proper package should be `isparta-loader`
