### PR TITLE
Adding "repository" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "start": "webpack-dev-server --inline --hot"
   },
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scup/atellier.git"
+  },
   "license": "MIT",
   "keywords": [
     "react",


### PR DESCRIPTION
When you access Atellier's npm page, is not able to go to GitHub repository because the property "repository" is not specified in package.json
