### PR TITLE
Fix context passthrough and bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react": "^0.14.0 || ^15.0.0-0",
+    "react-dom": "^0.14.0 || ^15.0.0-0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-atellier",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Scup/Sprinklr Team <developer@scup.com.br>",
   "description": "The smartest way to share interactive components with your team",
   "main": "./dist/react-atellier.js",

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import reactdom from 'react-dom';
+import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 
 class Stage extends React.Component {
@@ -35,7 +35,7 @@ class Stage extends React.Component {
     let { component, properties } = this.props;
     let targetRender = document.getElementById('__stage_render__');
     try {
-      reactdom.unstable_renderSubtreeIntoContainer(
+      ReactDOM.unstable_renderSubtreeIntoContainer(
         this,
         <div className="stage">
           {this._renderStageBoard()},
@@ -45,7 +45,7 @@ class Stage extends React.Component {
       );
     } catch(error) {
       targetRender.innerHTML = '';
-      reactdom.unstable_renderSubtreeIntoContainer(
+      ReactDOM.unstable_renderSubtreeIntoContainer(
         this,
         <div className="stage">
           {this._renderErrorAlert(error)}

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -35,7 +35,8 @@ class Stage extends React.Component {
     let { component, properties } = this.props;
     let targetRender = document.getElementById('__stage_render__');
     try {
-      reactdom.render(
+      reactdom.unstable_renderSubtreeIntoContainer(
+        this,
         <div className="stage">
           {this._renderStageBoard()},
           {this._renderStageTools()}
@@ -44,7 +45,8 @@ class Stage extends React.Component {
       );
     } catch(error) {
       targetRender.innerHTML = '';
-      reactdom.render(
+      reactdom.unstable_renderSubtreeIntoContainer(
+        this,
         <div className="stage">
           {this._renderErrorAlert(error)}
         </div>,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,8 @@ module.exports = {
   },
   externals: {
       // Use external version of React
-      "react": "React"
+      'react': 'react',
+      'react-dom': 'react-dom'
   },
   module: {
     loaders: [


### PR DESCRIPTION
- Pass context to rendered components. https://github.com/sompylasar/atellier/commit/98357eda93f4e09b1a51beccee15e17880ef43f7
- Use common spelling of `ReactDOM`. https://github.com/sompylasar/atellier/commit/aa1c3a7d42b985534237e6f0f908155ae61dba05
- Use external `react` and `react-dom`. https://github.com/sompylasar/atellier/commit/034164ba1016eb342f000d3ca94dd301e4a9bf1b
